### PR TITLE
fix(ci-config): prevent missing output error bc of no tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,6 +119,7 @@ jobs:
           name: Run jest
           command: |
             yarn run test > coverage/input_jest.txt
+            touch coverage/output_jest.txt
             ./node_modules/.bin/format-coverage coverage/input_jest.txt coverage/output_jest.txt /home/circleci/project/app/javascript
             cat coverage/output_jest.txt | ./bin/reviewdog -reporter=github-pr-review -efm="%f:%l:%c: %m"
 


### PR DESCRIPTION
### Contexto

App sandbox para onboarding trainees

### Qué se esta haciendo

Evita error en CircleCI de coverage de front por no tener tests

#### En particular hay que revisar

-----------
#### Info Adicional (pantallazos, links, fuentes, etc.)
![image](https://user-images.githubusercontent.com/12057523/208692950-3f660337-059d-42c1-8b47-4131376dea62.png)